### PR TITLE
remove quotes around $service variable

### DIFF
--- a/application/controllers/ShowController.php
+++ b/application/controllers/ShowController.php
@@ -168,7 +168,7 @@ class ShowController extends Controller
             if (! array_key_exists('icingaHost', $patterns)) continue;
 
             foreach ($set->loadTemplates() as $key => $template) {
-                if (strpos($template->getFilterString(), '$service') !== false) continue;
+                if (strpos($template->getFilterString(), $service) !== false) continue;
 
                 $imgParams = array(
                     'template' => $key,
@@ -228,7 +228,7 @@ class ShowController extends Controller
             if (! array_key_exists('icingaHost', $patterns)) continue;
 
             foreach ($set->loadTemplates() as $key => $template) {
-                if (strpos($template->getFilterString(), '$service') === false) continue;
+                if (strpos($template->getFilterString(), $service) === false) continue;
 
                 $imgParams = array(
                     'template' => $key,
@@ -289,7 +289,7 @@ class ShowController extends Controller
 
             foreach ($set->loadTemplates() as $key => $template) {
 
-                if (strpos($template->getFilterString(), '$service') === false) continue;
+                if (strpos($template->getFilterString(), $service) === false) continue;
 
                 $this->view->templates[$key] = $template;
 


### PR DESCRIPTION
This fixes https://dev.icinga.org/issues/11572

This still leaves $hostname being quoted, I don't know if that needs to go as well.
