### PR TITLE
allow service templates without using variable $service

### DIFF
--- a/application/controllers/ShowController.php
+++ b/application/controllers/ShowController.php
@@ -228,7 +228,15 @@ class ShowController extends Controller
             if (! array_key_exists('icingaHost', $patterns)) continue;
 
             foreach ($set->loadTemplates() as $key => $template) {
-                if (strpos($template->getFilterString(), '$service') === false) continue;
+                # TS: use only templates whose graphite target string contains
+                # the name of the service
+                $resolvedFilter =
+                   GraphiteUtil::replace(
+                      GraphiteUtil::replace(
+                         $template->getFilterString(),
+                            'service', $service),
+                      'hostname', $hostname);
+                if (strpos($resolvedFilter, $service) === false) continue;
 
                 $imgParams = array(
                     'template' => $key,


### PR DESCRIPTION
To be more flexible with the templates do not require that the filter of a template has to use the variable $service but require that the name of the service is part of the filter. Remark: To Manage this the variables have to be resolved (see code changes).
