### PR TITLE
Add '^' to the list of supported graphite characters.

### DIFF
--- a/library/Graphite/Graphing/MetricsQuery.php
+++ b/library/Graphite/Graphing/MetricsQuery.php
@@ -186,6 +186,6 @@ class MetricsQuery implements Queryable, Filterable, Fetchable
      */
     protected function escapeMetricStep($step)
     {
-        return preg_replace('/[^a-zA-Z0-9\*\-:[\]$]/', '_', $step);
+        return preg_replace('/[^a-zA-Z0-9\*\-:^[\]$]/', '_', $step);
     }
 }


### PR DESCRIPTION
icinga2 allows carets in the names when pushing them to graphite. Don't transform these to underscore when retrieving the data.

Found via snmp-storage apply for where the disks are based on regular expressions, which creates service names like 'storage^/$$', or storage^_$$ after replacement of special characters.

Only lightly tested.