### PR TITLE
changed function to derivative on mysql counter values to get a real graph

### DIFF
--- a/templates/mysql.ini
+++ b/templates/mysql.ini
@@ -12,7 +12,7 @@ min = "0"
 yUnitSystem = "none"
 
 [mysql-Connections.functions]
-value = "alias(color($metric$, '#1a7dd7'), 'Connections')"
+value = "alias(color(nonNegativeDerivative($metric$), '#1a7dd7'), 'Connections')"
 
 
 [mysql-Open_files.graph]
@@ -131,7 +131,7 @@ min = "0"
 yUnitSystem = "none"
 
 [mysql-Qcache_not_cached.functions]
-value = "alias(color($metric$, '#1a7dd7'), 'Not cached queries')"
+value = "alias(color(nonNegativeDerivative($metric$), '#1a7dd7'), 'Not cached queries')"
 
 
 [mysql-Qcache_queries_in_cache.graph]
@@ -165,7 +165,7 @@ min = "0"
 yUnitSystem = "none"
 
 [mysql-Queries.functions]
-value = "alias(color($metric$, '#1a7dd7'), 'Queries')"
+value = "alias(color(nonNegativeDerivative($metric$), '#1a7dd7'), 'Queries')"
 
 
 [mysql-Questions.graph]
@@ -182,7 +182,7 @@ min = "0"
 yUnitSystem = "none"
 
 [mysql-Questions.functions]
-value = "alias(color($metric$, '#1a7dd7'), 'Questions')"
+value = "alias(color(nonNegativeDerivative($metric$), '#1a7dd7'), 'Questions')"
 
 
 [mysql-Table_locks_waited.graph]


### PR DESCRIPTION
Changed the mysql counter values to nonNegativeDerivative function to display real change in the graphs.

nonNegative should be used in case the counter is reseted after reboot, otherwise the graph would display wrong negative values.

![connections](https://user-images.githubusercontent.com/7584938/66467414-b2ed7580-ea84-11e9-81bd-d95530fc07ef.PNG)
![queriesandquestions](https://user-images.githubusercontent.com/7584938/66467424-b8e35680-ea84-11e9-8047-ddd178149704.PNG)
