### PR TITLE
Tiny improvements for template details

### DIFF
--- a/templates/disk.ini
+++ b/templates/disk.ini
@@ -14,5 +14,5 @@ title = "Disk $disk$"
 yUnitSystem = "binary"
 
 [disk.functions]
-value = "alias(color($metric$, '#1a7dd7'), 'Used (bytes)')"
+value = "alias(color($metric$, '#1a7dd7'), 'Free (bytes)')"
 max = "alias(color($metric$, '#cfd7e6'), 'Size (bytes)')"

--- a/templates/hostalive.ini
+++ b/templates/hostalive.ini
@@ -26,7 +26,7 @@ areaAlpha = "0.5"
 areaMode = "all"
 lineWidth = "2"
 min = "0"
-yUnitSystem = "none"
+yUnitSystem = "msec"
 
 [hostalive-pl.functions]
 pl.value = "alias(color($metric$, '#1a7dd7'), 'Packet loss (%)')"

--- a/templates/hostalive.ini
+++ b/templates/hostalive.ini
@@ -9,7 +9,7 @@ areaAlpha = "0.5"
 areaMode = "all"
 lineWidth = "2"
 min = "0"
-yUnitSystem = "none"
+yUnitSystem = "msec"
 
 [hostalive-rta.functions]
 rta.value = "alias(color(scale($metric$, 1000), '#1a7dd7'), 'Round trip time (ms)')"
@@ -26,7 +26,7 @@ areaAlpha = "0.5"
 areaMode = "all"
 lineWidth = "2"
 min = "0"
-yUnitSystem = "msec"
+yUnitSystem = "none"
 
 [hostalive-pl.functions]
 pl.value = "alias(color($metric$, '#1a7dd7'), 'Packet loss (%)')"

--- a/templates/icmp.ini
+++ b/templates/icmp.ini
@@ -30,7 +30,7 @@ areaAlpha = "0.5"
 areaMode = "all"
 lineWidth = "2"
 min = "0"
-yUnitSystem = "msec"
+yUnitSystem = "none"
 
 [icmp-pl.functions]
 pl.value = "alias(color($metric$, '#1a7dd7'), 'Packet loss (%)')"

--- a/templates/icmp.ini
+++ b/templates/icmp.ini
@@ -11,7 +11,7 @@ areaAlpha = "0.5"
 areaMode = "all"
 lineWidth = "2"
 min = "0"
-yUnitSystem = "none"
+yUnitSystem = "msec"
 
 [icmp-rt.functions]
 rtmin.value = "alias(color(scale($metric$, 1000), '#44bb77'), 'Min. round trip time (ms)')"
@@ -30,7 +30,7 @@ areaAlpha = "0.5"
 areaMode = "all"
 lineWidth = "2"
 min = "0"
-yUnitSystem = "none"
+yUnitSystem = "msec"
 
 [icmp-pl.functions]
 pl.value = "alias(color($metric$, '#1a7dd7'), 'Packet loss (%)')"

--- a/templates/ping.ini
+++ b/templates/ping.ini
@@ -26,7 +26,7 @@ areaAlpha = "0.5"
 areaMode = "all"
 lineWidth = "2"
 min = "0"
-yUnitSystem = "msec"
+yUnitSystem = "none"
 
 [ping-pl.functions]
 pl.value = "alias(color($metric$, '#1a7dd7'), 'Packet loss (%)')"

--- a/templates/ping.ini
+++ b/templates/ping.ini
@@ -9,7 +9,7 @@ areaAlpha = "0.5"
 areaMode = "all"
 lineWidth = "2"
 min = "0"
-yUnitSystem = "none"
+yUnitSystem = "msec"
 
 [ping-rta.functions]
 rta.value = "alias(color(scale($metric$, 1000), '#1a7dd7'), 'Round trip time (ms)')"
@@ -26,7 +26,7 @@ areaAlpha = "0.5"
 areaMode = "all"
 lineWidth = "2"
 min = "0"
-yUnitSystem = "none"
+yUnitSystem = "msec"
 
 [ping-pl.functions]
 pl.value = "alias(color($metric$, '#1a7dd7'), 'Packet loss (%)')"

--- a/templates/swap.ini
+++ b/templates/swap.ini
@@ -13,5 +13,5 @@ min = "0"
 yUnitSystem = "binary"
 
 [swap.functions]
-value = "alias(color($metric$, '#1a7dd7'), 'Used (bytes)')"
+value = "alias(color($metric$, '#1a7dd7'), 'Free (bytes)')"
 max = "alias(color($metric$, '#cfd7e6'), 'Size (bytes)')"


### PR DESCRIPTION
**ping.ini icmp.ini hostalive.ini**
Changed yUnitSystem from "none" to "msec" to be more accurate
**disk.ini swap.ini**
Changed legend from "Used" to "Free" as the default perfdata output of Icinga plugins delivered are based on this. Otherwise the graphs are "wrong way around". The screenshot of changed behaviour should explain it as a living example. If the filled area would be "Used" the state would be critical (nearly all Swap used), but it isn't as the filled area is still available.
![Swap Graph](https://user-images.githubusercontent.com/13959569/79362642-2053f480-7f47-11ea-91fb-a2a56ca1ca13.png)

P.S.: This is my first other project pull request, so please be gentle ;)
