### PR TITLE
Add "host" ping graphs

### DIFF
--- a/templates/ping-host.ini
+++ b/templates/ping-host.ini
@@ -1,0 +1,32 @@
+[ping-rta-host.graph]
+check_command = "ping, ping4, ping6, ping-windows"
+
+[ping-rta-host.metrics_filters]
+rta.value = "$host_name_template$.perfdata.rta.value"
+
+[ping-rta-host.urlparams]
+areaAlpha = "0.5"
+areaMode = "all"
+lineWidth = "2"
+min = "0"
+yUnitSystem = "none"
+
+[ping-rta-host.functions]
+rta.value = "alias(color(scale($metric$, 1000), '#1a7dd7'), 'Round trip time (ms)')"
+
+
+[ping-pl-host.graph]
+check_command = "ping, ping4, ping6"
+
+[ping-pl-host.metrics_filters]
+pl.value = "$host_name_template$.perfdata.pl.value"
+
+[ping-pl-host.urlparams]
+areaAlpha = "0.5"
+areaMode = "all"
+lineWidth = "2"
+min = "0"
+yUnitSystem = "none"
+
+[ping-pl-host.functions]
+pl.value = "alias(color($metric$, '#1a7dd7'), 'Packet loss (%)')"


### PR DESCRIPTION
The default ping template covers "service" ping checks only. Clone
ping.ini as ping-host.ini and adjust the contents for host checks:

 * Rename sections from ping-pl.* to ping-pl-host.* and similar
 * Replace service_name_template by host_name_template

Debugging credits: @natureshadow