### PR TITLE
Skip missing template metrics

### DIFF
--- a/library/Graphite/Web/Widget/GraphImage.php
+++ b/library/Graphite/Web/Widget/GraphImage.php
@@ -94,6 +94,10 @@ class GraphImage extends AbstractWidget
             $allVars = [];
 
             foreach ($template->getCurves() as $curveName => $curve) {
+                if (!isset($metrics[$curveName])) {
+                    continue;
+                }
+
                 $vars = $curve[0]->reverseResolve($metrics[$curveName]);
 
                 if ($vars !== false) {


### PR DESCRIPTION
Fix for "Make all macros used in a template's metrics filters available in its functions, too" #217 as requested by @Al2Klimov