### PR TITLE
Avoid inline styles

### DIFF
--- a/library/Graphite/Web/Widget/Graphs.php
+++ b/library/Graphite/Web/Widget/Graphs.php
@@ -304,10 +304,10 @@ abstract class Graphs extends AbstractWidget
                                 $actheight = $this->height;
                             }
                             $actwidth = $this->width;
-                            $actwidthfix = "";
+                            $explicitWidth = false;
                             if (array_key_exists("width", $urlParams)) {
                                 $actwidth = $urlParams["width"]->resolve(['width']);
-                                $actwidthfix = "width: {$actwidth}px; ";
+                                $explicitWidth = $actwidth;
                             }
 
                             if ($this->renderInline) {
@@ -344,8 +344,12 @@ abstract class Graphs extends AbstractWidget
 
                                 $img = '<img id="graphiteImg-' . md5((string) $imageUrl) . '"'
                                     . " src=\"$src\" data-actualimageurl=\"$imageUrl\" class=\"detach graphiteImg\""
-                                    . " alt=\"\" width=\"$actwidth\" height=\"$actheight\""
-                                    . " style=\"min-width: {$actwidth}px; $actwidthfix min-height: {$actheight}px;\">";
+                                    . " alt=\"\" width=\"$actwidth\" height=\"$actheight\"";
+                                if ($explicitWidth !== false) {
+                                    $img .= " data-width=\"$explicitWidth\"";
+                                }
+
+                                $img .= '>';
                             }
 
                             $currentGraphs[] = [$img, $metricVariables, $bestPos];

--- a/public/css/module.less
+++ b/public/css/module.less
@@ -1,20 +1,5 @@
-div.images {
-    h3 {
-        clear: both;
-    }
-
-    img.svg {
-        float: left;
-        border: none;
-    }
-
-}
-
-div.images.object-detail-view {
-  img.graphiteImg {
+.images.object-detail-view > img {
     width: 100%;
-    display: block;
-  }
 }
 
 .timerangepicker-container {

--- a/public/css/module.less
+++ b/public/css/module.less
@@ -11,8 +11,6 @@ div.images {
 }
 
 div.images.object-detail-view {
-  display: block;
-
   img.graphiteImg {
     width: 100%;
     display: block;

--- a/public/js/module.js
+++ b/public/js/module.js
@@ -79,7 +79,15 @@
             container.querySelectorAll('img.graphiteImg[data-actualimageurl]').forEach(img => {
                 let params = { ...this.colorParams }; // Theming ftw!
                 params.r = (new Date()).getTime(); // To bypass the browser cache
-                params.width = img.scrollWidth; // It's either fixed or dependent on parent width
+                params.width = img.scrollWidth;
+                if ('width' in img.dataset) {
+                    // If the width is defined in the data attributes, it has been explicitly defined in a template and
+                    // therefore must be handled specially. In detail areas the image must not be scaled to 100% and
+                    // in the other views it must not exceed the width of the parent container.
+                    // Note the `+str` which will convert str to number.
+                    params.width = Math.min(+img.dataset.width, img.parentElement.clientWidth);
+                    img.style.width = params.width + 'px';
+                }
 
                 img.src = this.icinga.utils.addUrlParams(img.dataset.actualimageurl, params);
             });


### PR DESCRIPTION
If the width of a graph has been explicitly defined in a template, it
must be handled specially: In detail areas, the image must not be scaled
to 100% and in the other views, it must not exceed the width of the
parent container. So far, this has been achieved using inline styles,
which must be avoided to support strict CSP. This is now done using JS.

Additionally I have cleaned up related CSS rules.