### PR TITLE
Fix trying to load vendor loaders that don't exists

### DIFF
--- a/run.php
+++ b/run.php
@@ -4,9 +4,6 @@
 
 use Icinga\Module\Graphite\ProvidedHook\Icingadb\IcingadbSupport;
 
-require_once $this->getLibDir() . '/vendor/Psr/Loader.php';
-require_once $this->getLibDir() . '/vendor/iplx/Loader.php';
-
 $this->provideHook('monitoring/DetailviewExtension');
 $this->provideHook('icingadb/IcingadbSupport');
 $this->provideHook('icingadb/HostDetailExtension');


### PR DESCRIPTION
Leftovers from https://github.com/Icinga/icingaweb2-module-graphite/pull/312