### PR TITLE
Add Graphite Web HTTP request timeout option

### DIFF
--- a/application/forms/Config/BackendForm.php
+++ b/application/forms/Config/BackendForm.php
@@ -53,6 +53,16 @@ class BackendForm extends ConfigForm
                     'label'         => $this->translate('Connect insecurely'),
                     'description'   => $this->translate('Check this to not verify the remote\'s TLS certificate')
                 ]
+            ],
+            [
+                'number',
+                'graphite_timeout',
+                [
+                    'label'         => $this->translate('Request timeout'),
+                    'description'   => $this->translate('The timeout for HTTP requests to Graphite Web'),
+                    'min'           => 0,
+                    'placeholder'   => 10
+                ]
             ]
         ]);
     }

--- a/library/Graphite/Graphing/GraphingTrait.php
+++ b/library/Graphite/Graphing/GraphingTrait.php
@@ -73,6 +73,7 @@ trait GraphingTrait
                     ->setUser($graphite->user)
                     ->setPassword($graphite->password)
                     ->setInsecure((bool) $graphite->insecure)
+                    ->setTimeout(isset($graphite->timeout) ? intval($graphite->timeout) : 10)
             );
         }
 

--- a/library/Graphite/Graphing/GraphiteWebClient.php
+++ b/library/Graphite/Graphing/GraphiteWebClient.php
@@ -41,6 +41,13 @@ class GraphiteWebClient
     protected $insecure = false;
 
     /**
+     * Timeout for every Graphite Web HTTP request
+     *
+     * @var ?int
+     */
+    protected $timeout;
+
+    /**
      * HTTP client
      *
      * @var ClientInterface
@@ -79,9 +86,12 @@ class GraphiteWebClient
         // TODO(ak): keep connections alive (TCP handshakes are a bit expensive and TLS handshakes are very expensive)
         return (string) $this->httpClient->send(
             new Request($method, $this->completeUrl($url)->getAbsoluteUrl(), $headers, $body),
-            ['curl' => [
-                CURLOPT_SSL_VERIFYPEER => ! $this->insecure
-            ]]
+            [
+                'curl' => [
+                    CURLOPT_SSL_VERIFYPEER => ! $this->insecure
+                ],
+                'timeout' => $this->timeout ?? 10
+            ]
         )->getBody();
     }
 
@@ -192,6 +202,30 @@ class GraphiteWebClient
     public function setInsecure($insecure = true)
     {
         $this->insecure = $insecure;
+
+        return $this;
+    }
+
+    /**
+     * Get the HTTP request timeout
+     *
+     * @return ?int
+     */
+    public function getTimeout(): ?int
+    {
+        return $this->timeout;
+    }
+
+    /**
+     * Set the HTTP request timeout
+     *
+     * @param ?int $timeout
+     *
+     * @return $this
+     */
+    public function setTimeout(?int $timeout): self
+    {
+        $this->timeout = $timeout;
 
         return $this;
     }


### PR DESCRIPTION
If the Graphite Web server is unreachable, all requests for frontend pages containing graphs hang until the backend HTTP request times out, resulting in a very poor UX.

The Guzzle documentation states that the default behaviour is to wait indefinitely, however in our testing the cURL handler has an internal default of 30 seconds:

https://docs.guzzlephp.org/en/stable/request-options.html#timeout

This commit makes the HTTP request timeout configurable and sets a reasonable default of 10 seconds.